### PR TITLE
👌 IMPROVE: Allow `file_size` to be passed to `ZipPath.open`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.2.0
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
@@ -8,7 +8,7 @@ repos:
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.10
+  rev: 0.7.14
   hooks:
   - id: mdformat
     additional_dependencies:
@@ -22,7 +22,7 @@ repos:
   hooks:
   - id: isort
 -   repo: https://github.com/ikamensh/flynt/
-    rev: '0.69'
+    rev: '0.76'
     hooks:
     -   id: flynt
         args: [
@@ -30,7 +30,7 @@ repos:
             '--fail-on-change',
         ]
 - repo: https://github.com/psf/black
-  rev: 21.11b1
+  rev: 22.3.0
   hooks:
   - id: black
 - repo: https://gitlab.com/pycqa/flake8
@@ -44,7 +44,7 @@ repos:
     - flake8-rst-docstrings==0.0.14
     - flake8-markdown==0.2.0
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.942
     hooks:
     -   id: mypy
         pass_filenames: true

--- a/archive_path/zip_path.py
+++ b/archive_path/zip_path.py
@@ -30,6 +30,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
@@ -54,7 +55,7 @@ __all__ = (
 )
 
 NOTSET = ()
-NotSetType = Any  # once python 3.7 dropped: Literal[NOTSET]
+NotSetType = Any
 
 
 class ZipPath:
@@ -91,7 +92,7 @@ class ZipPath:
         self,
         path: Union[str, Path, "ZipPath"],
         *,
-        mode: str = "r",
+        mode: Literal["r", "w", "x", "a"] = "r",
         at: str = "",  # pylint: disable=invalid-name
         allow_zip64: bool = True,
         compression: int = zipfile.ZIP_DEFLATED,
@@ -273,7 +274,7 @@ class ZipPath:
     @contextmanager  # noqa: A003
     def open(  # noqa: A003
         self,
-        mode: str = "rb",
+        mode: Literal["rb", "wb"] = "rb",
         *,
         compression: Union[NotSetType, int] = NOTSET,
         level: Union[NotSetType, int] = NOTSET,
@@ -317,7 +318,8 @@ class ZipPath:
                 raise FileNotFoundError(self.at)
         else:
             raise ValueError('open() requires mode "rb" or "wb"')
-        with self.root.open(zinfo, mode=mode[0]) as handle:
+        zipmode: Literal["r", "w"] = mode[0]  # type: ignore
+        with self.root.open(zinfo, mode=zipmode) as handle:
             yield handle
 
     def _write(self, content: Union[str, bytes]):
@@ -688,7 +690,7 @@ class ZipFileExtra(zipfile.ZipFile):
     def __init__(  # noqa: C901
         self,
         file: Union[str, Path, IO],
-        mode: str = "r",
+        mode: Literal["r", "w", "x", "a"] = "r",
         compression: int = zipfile.ZIP_STORED,
         allowZip64: bool = True,
         compresslevel: Optional[int] = None,
@@ -733,7 +735,7 @@ class ZipFileExtra(zipfile.ZipFile):
         self.filelist: List[zipfile.ZipInfo] = FileList(self.NameToInfo, info_order)  # type: ignore
         self.compression: int = compression  # Method of compression
         self.compresslevel: Optional[int] = compresslevel
-        self.mode: str = mode
+        self.mode = mode
         self.pwd: Optional[str] = None
         self._comment: bytes = b""
         self._strict_timestamps: bool = strict_timestamps
@@ -771,7 +773,7 @@ class ZipFileExtra(zipfile.ZipFile):
         else:
             self._filePassed = 1
             self.fp = cast(IO, file)
-            self.filename = getattr(file, "name", None)
+            self.filename = getattr(file, "name", None)  # type: ignore
         self._fileRefCnt = 1
         self._lock = threading.RLock()
         self._seekable = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,14 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = "archive zip tar pathlib"
 
-requires-python=">3.6"
+requires-python=">=3.8"
 
 [tool.flit.metadata.requires-extra]
 test = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,15 @@
 envlist = py38
 isolated_build = True
 
-[testenv:py{37,38,39,310}]
+[testenv:py{38,39,310}]
 extras = test
 commands = pytest {posargs}
 
-[testenv:py{37,38,39,310}-cov]
+[testenv:py{38,39,310}-cov]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/archive_path {posargs}
 
-[testenv:py{37,38,39,310}-pre-commit]
+[testenv:py{38,39,310}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs}
 


### PR DESCRIPTION
This is used by `zipfile.open`, to compute if the `ZIP64` extension is required when writing