### PR TITLE
Dependencies: Add support for Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
   rev: 22.3.0
   hooks:
   - id: black
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8

--- a/archive_path/zip_path.py
+++ b/archive_path/zip_path.py
@@ -698,6 +698,7 @@ class ZipFileExtra(zipfile.ZipFile):
         compresslevel: Optional[int] = None,
         *,
         strict_timestamps: bool = True,
+        metadata_encoding: Optional[str] = None,
         name_to_info: Optional[abc.MutableMapping] = None,
         info_order: Sequence[str] = (),
     ):
@@ -714,7 +715,8 @@ class ZipFileExtra(zipfile.ZipFile):
         :param allowZip64: If True, zipfile will create ZIP files that use the ZIP64 extensions,
             when the zipfile is larger than 4 GiB
         :param strict_timestamps: when set to False, allows to zip files older than 1980-01-01
-
+        :param metadata_encoding: Specify member name encoding for reading metadata in the zipfile's
+            directory and file headers.
         :param name_to_info: The dictionary for storing mappings of filename -> ``ZipInfo``,
             if ``None``, defaults to ``{}``
         :param info_order: list of file names (if present) to write first to the central directory
@@ -741,6 +743,7 @@ class ZipFileExtra(zipfile.ZipFile):
         self.pwd: Optional[str] = None
         self._comment: bytes = b""
         self._strict_timestamps: bool = strict_timestamps
+        self.metadata_encoding = metadata_encoding
 
         self.filename: str
         self._filePassed: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = "archive zip tar pathlib"


### PR DESCRIPTION
Officially add support for Python 3.11 by adding it in the trove classifiers and run the CI workflow against it.

The code required a single fix to add compatiblity. The `ZipFile` class in the standard library got the `metadata_encoding` argument added, see: https://github.com/python/cpython/commit/a25a985535ccbb7df8caddc0017550ff4eae5855 This needed to be added to the `ZipExtra` class which essentially clones the class of the standard library. Without it, an `AttributeError` would be thrown when `_RealGetContents` would call `self.metadata_encoding`.